### PR TITLE
Add 'draft-rfcs' folder

### DIFF
--- a/draft-rfcs/README.md
+++ b/draft-rfcs/README.md
@@ -1,0 +1,8 @@
+# RFC drafts
+
+This folder contains drafts of RFCs that the group is preparing to submit.
+
+<!--
+Once the group has submitted RFCs, the drafts should be deleted from this folder,
+and links to the pull requests on the RFC repository should be listed here.
+-->


### PR DESCRIPTION
Since project groups are intended to propose RFCs, I think every project group will need this folder.